### PR TITLE
Fix bug caused by #comment nodes

### DIFF
--- a/src/lineWrapDetector.js
+++ b/src/lineWrapDetector.js
@@ -25,7 +25,9 @@
       el.parentNode.removeChild(el);
     }
     else {
-      el.innerHTML = wrapWords(el.innerText,'<span class="js-detect-wrap">','</span>');
+      if(el.innerText){
+        el.innerHTML = wrapWords(el.innerText,'<span class="js-detect-wrap">','</span>');
+      }
     }
   };
 


### PR DESCRIPTION
Upon stumbling on a "#comment" HTML DOM node the script would crash, as that node doesn't have the innerText property so you end up calling undefined.split(), thus causing an exception.

This simple commit fixes that by making sure that the node you are operating on has an innerText property, thus catching the "#comment" node edge case and any other similar edge cases that could be caused by other types of nodes unknown to me or new nodes that could be added in future revisions of the HTML standard.