### PR TITLE
Fix bug triggered when detecting same text twice

### DIFF
--- a/src/lineWrapDetector.js
+++ b/src/lineWrapDetector.js
@@ -10,6 +10,9 @@
   };
 
   var wrapWordsInChildElement = function(el) {
+    if(el.parentElement.className=="js-detect-wrap"){
+      return;
+    }
     if(el.nodeName == '#text') {
       var words = el.textContent.split(' ');
       for(var i=0;i<words.length;i++) {


### PR DESCRIPTION
When applying the code to the same text twice, everything is done over and the result ends up being a mess, this fix prevents the script from running again once it detects it has already been applied.